### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  

- `contents: read` (needed for `actions/checkout`)
- `actions: read` (safe/read-only scope for actions metadata; optional but explicit)

No write permission is required for this workflow as shown (build/test/release generation + artifact upload). Artifact upload does not require repo-content write permission.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
